### PR TITLE
Added option to return `cs` of feature that fails filter.

### DIFF
--- a/alignparse/targets.py
+++ b/alignparse/targets.py
@@ -683,7 +683,8 @@ class Targets:
                         to_csv=False,
                         overwrite=False,
                         multi_align='primary',
-                        ncpus=-1,
+                        filtered_cs=False,
+                        ncpus=-1
                         ):
         """Align query sequences and then parse alignments.
 
@@ -723,6 +724,10 @@ class Targets:
         multi_align : {'primary'}
             How to handle multiple alignments. Currently only option is
             'primary', which ignores all secondary alignments.
+        filtered_cs : bool
+            Add `cs` tag that failed the filter to filtered dataframe along
+            with filter reason. Allows for more easily investigating why
+            reads are failing the filters.
         ncpus : int
             Number of CPUs to use; -1 means all available.
 
@@ -812,7 +817,8 @@ class Targets:
                                  itertools.repeat(multi_align),
                                  itertools.repeat(True),
                                  df['subdir'],
-                                 itertools.repeat(overwrite)
+                                 itertools.repeat(overwrite),
+                                 itertools.repeat(filtered_cs)
                                  )
 
         # close, clear pool: https://github.com/uqfoundation/pathos/issues/111
@@ -1053,8 +1059,10 @@ class Targets:
                               target_seqs=self.target_seqs)
                 tname = a.target_name
 
-                is_filtered, parse_tup = self.\
-                    _parse_single_Alignment(a, tname, filtered_cs)
+                is_filtered, parse_tup = self._parse_single_Alignment(
+                                                                a,
+                                                                tname,
+                                                                filtered_cs)
 
                 if is_filtered:
                     readstats[tname]['filtered'] += 1

--- a/alignparse/targets.py
+++ b/alignparse/targets.py
@@ -1053,9 +1053,8 @@ class Targets:
                               target_seqs=self.target_seqs)
                 tname = a.target_name
 
-                is_filtered, parse_tup = self._parse_single_Alignment(a,
-                                                                      tname,
-                                                                      filtered_cs)
+                is_filtered, parse_tup = self.\
+                    _parse_single_Alignment(a, tname, filtered_cs)
 
                 if is_filtered:
                     readstats[tname]['filtered'] += 1
@@ -1134,7 +1133,6 @@ class Targets:
         a : :class:`alignparse.cs_tag.Alignment`
         targetname : str
         filtered_cs : bool
-            If `True` also return `cs` tag of feature that failed filter.
 
         Returns
         --------

--- a/alignparse/targets.py
+++ b/alignparse/targets.py
@@ -904,7 +904,8 @@ class Targets:
         return readstats, aligned, filtered
 
     def parse_alignment(self, samfile, multi_align='primary',
-                        to_csv=False, csv_dir=None, overwrite_csv=False):
+                        to_csv=False, csv_dir=None, overwrite_csv=False,
+                        filtered_cs=False):
         """Parse alignment features as specified in `feature_parse_specs`.
 
         Parameters
@@ -925,6 +926,10 @@ class Targets:
         overwrite_csv : bool
             If using `to_csv`, do we overwrite existing CSV files or
             raise an error if they already exist?
+        filtered_cs : bool
+            Add `cs` tag that failed the filter to filtered dataframe along
+            with filter reason. Allows for more easily investigating why
+            reads are failing the filters.
 
         Returns
         -------
@@ -945,6 +950,8 @@ class Targets:
             - 'filtered' is a dict keyed by name of each target. Entries are
               `pandas.DataFrame` with a row for each filtered aligned read
               giving the query name and the reason it was filtered.
+              If `filtered_cs` is `True` then, add a column to the 'filtered'
+              `pandas.DataFrame`s with the `cs` tag that failed the filter.
 
             If `to_csv` is `True`, then `aligned` and `filtered` give
             names of CSV files holding data frames.
@@ -990,7 +997,11 @@ class Targets:
         readstats = {t: {'filtered': 0, 'aligned': 0}
                      for t in self.target_names}
 
-        filtered_cols = ['query_name', 'filter_reason']
+        if filtered_cs:
+            filtered_cols = ['query_name', 'filter_reason', 'filter_cs']
+        else:
+            filtered_cols = ['query_name', 'filter_reason']
+
         if to_csv:
             filtered = {t: os.path.join(csv_dir, t.replace(' ', '_') +
                                         '_filtered.csv')
@@ -1042,7 +1053,9 @@ class Targets:
                               target_seqs=self.target_seqs)
                 tname = a.target_name
 
-                is_filtered, parse_tup = self._parse_single_Alignment(a, tname)
+                is_filtered, parse_tup = self._parse_single_Alignment(a,
+                                                                      tname,
+                                                                      filtered_cs)
 
                 if is_filtered:
                     readstats[tname]['filtered'] += 1
@@ -1113,22 +1126,26 @@ class Targets:
         else:
             return self._feature_parse_specs[targetname][featurename]['return']
 
-    def _parse_single_Alignment(self, a, targetname):
+    def _parse_single_Alignment(self, a, targetname, filtered_cs=False):
         """Parse a single alignment.
 
         Parameters
         ----------
         a : :class:`alignparse.cs_tag.Alignment`
         targetname : str
+        filtered_cs : bool
+            If `True` also return `cs` tag of feature that failed filter.
 
         Returns
         --------
         2-tuple
             Tuple `(is_filtered, parse_tup)` where `is_filtered` is bool
             indicating if alignment fails `feature_parse_specs` filters.
-            If it fails, `parse_tup` is 2-tuple `(query_name, filter_reason)`.
-            If it passes, `parse_tup` is list giving values specified
-            by :meth:`_parse_returnvals` for `targetname`.
+            If it fails and `filtered_cs` is `False`, `parse_tup` is 2-tuple
+            `(query_name, filter_reason)`. If it fails and `filtered_cs` is
+            `True`, `parse_tup` is tuple `(query_name, filter_reason,
+            filtered_cs)`. If it passes, `parse_tup` is list giving values
+            specified by :meth:`_parse_returnvals` for `targetname`.
 
         """
         query_name = a.query_name
@@ -1148,7 +1165,7 @@ class Targets:
         for feature in self.features_to_parse(targetname):
             feat_info = a.extract_cs(feature.start, feature.end)
             if feat_info is None:
-                # feature is full clipped, determine which end
+                # feature is fully clipped, determine which end
                 if a.target_clip5 >= feature.end:
                     clip5 = feature.length
                     clip3 = 0
@@ -1176,7 +1193,10 @@ class Targets:
                            }
             for key, valmax in target_parse_filters[featurename].items():
                 if filter_vals[key] > valmax:
-                    return True, (query_name, f"{featurename} {key}")
+                    if filtered_cs:
+                        return True, (query_name, f"{featurename} {key}", cs)
+                    else:
+                        return True, (query_name, f"{featurename} {key}")
 
             # get return values
             for return_name in self._parse_returnvals(targetname, featurename):

--- a/notebooks/VEP_pilot.ipynb
+++ b/notebooks/VEP_pilot.ipynb
@@ -744,7 +744,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -763,7 +763,7 @@
     "for run in pacbio_runs.itertuples():\n",
     "    \n",
     "    print(f\"Parsing PacBio run {run.name}\")\n",
-    "    run_readstats, run_aligned, run_filtered = targets.parse_alignment(run.alignments)\n",
+    "    run_readstats, run_aligned, run_filtered = targets.parse_alignment(run.alignments, filtered_cs=True)\n",
     "    \n",
     "    # when concatenating add the run name to keep track of runs for results\n",
     "    readstats.append(run_readstats\n",
@@ -793,7 +793,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -866,7 +866,7 @@
        "4                 unmapped      2  vep_pilot"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -877,7 +877,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -913,7 +913,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -939,6 +939,7 @@
        "      <th></th>\n",
        "      <th>query_name</th>\n",
        "      <th>filter_reason</th>\n",
+       "      <th>filter_cs</th>\n",
        "      <th>run_name</th>\n",
        "    </tr>\n",
        "  </thead>\n",
@@ -947,30 +948,35 @@
        "      <td>0</td>\n",
        "      <td>m54228_190605_190010/4194436/ccs</td>\n",
        "      <td>gene mutation_nt_count</td>\n",
+       "      <td>:8*ga:23*ag:8*ga:23*ct:15*ag:37*ag:8*ct:11*tc:...</td>\n",
        "      <td>vep_pilot</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>1</td>\n",
        "      <td>m54228_190605_190010/4194440/ccs</td>\n",
        "      <td>query_clip5</td>\n",
+       "      <td>None</td>\n",
        "      <td>vep_pilot</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>2</td>\n",
        "      <td>m54228_190605_190010/4194442/ccs</td>\n",
        "      <td>termini5 clip5</td>\n",
+       "      <td></td>\n",
        "      <td>vep_pilot</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>3</td>\n",
        "      <td>m54228_190605_190010/4194449/ccs</td>\n",
        "      <td>query_clip3</td>\n",
+       "      <td>None</td>\n",
        "      <td>vep_pilot</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <td>4</td>\n",
        "      <td>m54228_190605_190010/4194452/ccs</td>\n",
        "      <td>query_clip5</td>\n",
+       "      <td>None</td>\n",
        "      <td>vep_pilot</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -978,15 +984,22 @@
        "</div>"
       ],
       "text/plain": [
-       "                         query_name           filter_reason   run_name\n",
-       "0  m54228_190605_190010/4194436/ccs  gene mutation_nt_count  vep_pilot\n",
-       "1  m54228_190605_190010/4194440/ccs             query_clip5  vep_pilot\n",
-       "2  m54228_190605_190010/4194442/ccs          termini5 clip5  vep_pilot\n",
-       "3  m54228_190605_190010/4194449/ccs             query_clip3  vep_pilot\n",
-       "4  m54228_190605_190010/4194452/ccs             query_clip5  vep_pilot"
+       "                         query_name           filter_reason  \\\n",
+       "0  m54228_190605_190010/4194436/ccs  gene mutation_nt_count   \n",
+       "1  m54228_190605_190010/4194440/ccs             query_clip5   \n",
+       "2  m54228_190605_190010/4194442/ccs          termini5 clip5   \n",
+       "3  m54228_190605_190010/4194449/ccs             query_clip3   \n",
+       "4  m54228_190605_190010/4194452/ccs             query_clip5   \n",
+       "\n",
+       "                                           filter_cs   run_name  \n",
+       "0  :8*ga:23*ag:8*ga:23*ct:15*ag:37*ag:8*ct:11*tc:...  vep_pilot  \n",
+       "1                                               None  vep_pilot  \n",
+       "2                                                     vep_pilot  \n",
+       "3                                               None  vep_pilot  \n",
+       "4                                               None  vep_pilot  "
       ]
      },
-     "execution_count": 20,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -997,7 +1010,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -1047,7 +1060,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -1164,7 +1177,7 @@
        "4         ATTCCA                     C                     A  vep_pilot  "
       ]
      },
-     "execution_count": 22,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1177,7 +1190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -1294,7 +1307,7 @@
        "4         GGAGTC                     T                     G  vep_pilot  "
       ]
      },
-     "execution_count": 23,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1304,6 +1317,20 @@
     "print(show_target1)\n",
     "aligned[show_target1].head()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/VEP_pilot.ipynb
+++ b/notebooks/VEP_pilot.ipynb
@@ -489,7 +489,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ccs_summaries = alignparse.ccs.Summaries(pacbio_runs)"
+    "ccs_summaries = alignparse.ccs.Summaries(pacbio_runs, ncpus=1)"
    ]
   },
   {
@@ -744,7 +744,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -793,7 +793,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -866,7 +866,7 @@
        "4                 unmapped      2  vep_pilot"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -877,7 +877,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -913,7 +913,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -999,7 +999,7 @@
        "4                                               None  vep_pilot  "
       ]
      },
-     "execution_count": 32,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1010,7 +1010,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -1060,7 +1060,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -1177,7 +1177,7 @@
        "4         ATTCCA                     C                     A  vep_pilot  "
       ]
      },
-     "execution_count": 29,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1190,7 +1190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -1307,7 +1307,7 @@
        "4         GGAGTC                     T                     G  vep_pilot  "
       ]
      },
-     "execution_count": 30,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
Have not implemented in RecA tests, but wanted to get this pushed as it may help Allie figure out what's going on with one of her libraries that keeps failing the spacer filters. 