### PR TITLE
Set up to automatically run travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,6 @@ script:
 branches:
   only:
     - master
+
+notifications:
+  slack: jbloomlab:0mZZc056qnzqe1B2BMJp1FHL

--- a/nbval_sanitize.cfg
+++ b/nbval_sanitize.cfg
@@ -5,3 +5,8 @@
 [pandas_index_cell_header]
 regex: <t[dh]>\d+</t[dh]>
 replace: pandex_index_cell_header
+
+# Avoid errors due to different figure sizes
+[matplotlib_figure_size]
+regex: <Figure size [\d\.x]+ with \d+ Axes>
+replace: matplotlib_figure_size

--- a/nbval_sanitize.cfg
+++ b/nbval_sanitize.cfg
@@ -1,0 +1,7 @@
+# sanitize file for nbval testing of Jupyter notebooks
+
+# pandas data frames inconsistently are defined in HTML as table
+# or header elements. Simply replace both as `pandas_index_cell_header`
+[pandas_index_cell_header]
+regex: <t[dh]>\d+</t[dh]>
+replace: pandex_index_cell_header

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = alignparse tests docs notebooks --nbval --ignore setup.py --ignore docs/_build --doctest-modules --doctest-glob='*.rst'
+addopts = alignparse tests docs notebooks --nbval --ignore setup.py --ignore docs/_build --doctest-modules --doctest-glob='*.rst' --sanitize-with nbval_sanitize.cfg

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -8,3 +8,4 @@ flake8-comprehensions
 flake8-bugbear
 flake8-print
 nbval
+dms_variants


### PR DESCRIPTION
Set up to automatically run the tests on Travis-CI.
This included the following changes:

1. Registering the repository with Travis-CI:
   https://travis-ci.org/jbloomlab/alignparse

2. Adding to `.travis.yml` Slack notifications for the
   test results.

3. Adding `dms_variants` to `test_requirements.txt` as this
   package is used in tests.

4. Creating the `nbval_sanitize.cfg` file and telling
   `.travis.yml` to use it so the pandas index cell output
   format doesn't cause tests to fail.