### PR TITLE
paper markdown formatting edits

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -48,7 +48,7 @@
     journal = {Journal of Virology},
     year = 2019,
     volume = {93},
-    pages = {e00500-19}
+    pages = {e00500-19},
     issue = 14,
     doi = {10.1128/JVI.00500-19}
 }

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -28,8 +28,8 @@ bibliography: paper.bib
 # Summary & Purpose
 
 Advances in sequencing technology have made it possible to generate large numbers of long, high-accuracy sequencing reads.
-For instance, the new PacBio Sequel platform can generate hundreds of thousands of high-quality circular consensus sequences in a single run [@Rhoads:2015, @Hebert:2018].
-Good programs exist for aligning these reads for genome assembly [@Chaisson:2012, @Li:2018].
+For instance, the new PacBio Sequel platform can generate hundreds of thousands of high-quality circular consensus sequences in a single run [@Rhoads:2015; @Hebert:2018].
+Good programs exist for aligning these reads for genome assembly [@Chaisson:2012; @Li:2018].
 However, these long reads can also be used for other purposes, such as sequencing PCR amplicons that contain various features of interest.
 For instance, PacBio circular consensus sequences have been used to identify the mutations in influenza viruses in single cells [@Russell:2019], or to link barcodes to gene mutants in deep mutational scanning [@Matreyek:2018].
 For such applications, the alignment of the sequences to the targets may be fairly trivial, but it is not trivial to then parse specific features of interest (such as mutations, unique molecular identifiers, cell barcodes, and flanking sequences) from these alignments.


### PR DESCRIPTION
When making `pdf`, noticed some bugs in the original markdown formatting of the paper and bibliography. This commit fixes those. 