### PR TITLE
parse n passes tags from `ccs` version 5.0 FASTQs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,16 +6,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
+0.1.5
+-----
+
+Added
++++++
+* ``Summaries`` now parses ``np`` (number of passes) tags from ``ccs`` version 5.0 FASTQs.
+
 0.1.4
 -----
 
 Added
 +++++
+* ``Summaries`` now handles summaries from ``ccs`` version 5.0
 
 0.1.3
 ------
-
-* ``Summaries`` now handles summaries from ``ccs`` version 5.0
 
 Added
 +++++

--- a/alignparse/__init__.py
+++ b/alignparse/__init__.py
@@ -7,5 +7,5 @@ alignparse
 
 __author__ = '`the Bloom lab <https://research.fhcrc.org/bloom/en.html>`_'
 __email__ = 'jbloom@fredhutch.org'
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 __url__ = 'https://github.com/jbloomlab/alignparse'

--- a/alignparse/ccs.py
+++ b/alignparse/ccs.py
@@ -747,6 +747,28 @@ def get_ccs_stats(fastqfile, *, pass_tag='np'):
 
     Example
     -------
+    Test with ``np`` tag in format from ``ccs`` version 5.0.
+
+    >>> fastqfile = tempfile.NamedTemporaryFile(mode='w')
+    >>> _ = fastqfile.write(textwrap.dedent('''
+    ...   @m54228_190118_102822/4194373/ccs np=18
+    ...   GGTACCACACTCTTTCCCTACACGACGCTCTGCCGATCTCGGCCATTACGTGTTTTATCTA
+    ...   +
+    ...   ~~~~{~~~~~~~c~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~i~~~~~~~(
+    ...   @m54228_190118_102822/4194374/ccs np=51
+    ...   GCACGGCGTCACACTTTGCTATGCCATAGCATGTTTATCCATAAGATTAGCGGATCCTACCT
+    ...   +
+    ...   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    ...   ''').lstrip())
+    >>> fastqfile.flush()
+    >>> get_ccs_stats(fastqfile.name)  # doctest: +NORMALIZE_WHITESPACE
+    CCS_Stats(passes=array([18, 51]),
+              accuracy=array([0.99672907, 1.        ]),
+              length=array([61, 62]))
+    >>> fastqfile.close()
+
+    Test with ``np`` tag in format from ``ccs`` version 4.0.
+
     >>> fastqfile = tempfile.NamedTemporaryFile(mode='w')
     >>> _ = fastqfile.write(textwrap.dedent('''
     ...   @m54228_190118_102822/4194373/ccs np:i:18
@@ -788,7 +810,7 @@ def get_ccs_stats(fastqfile, *, pass_tag='np'):
     """
     if pass_tag:
         passmatch = re.compile(r'(?:^|\s)'  # start of str or space
-                               rf"{pass_tag}:i:(?P<pass>\d+)"
+                               rf"{pass_tag}(?::i:|=)(?P<pass>\d+)"
                                r'(?:\s|$)'  # end of str or space
                                )
         passes = []


### PR DESCRIPTION
`ccs` version 5.0 has changed how the "number of passes" (np) tag is encoded in the FASTQ file with the CCSs. This pull request makes `ccs.Summaries` now parse this new tag format in addition to the old one.

@khdusenbury, can you review and merge this. 