### PR TITLE
added `utils.MutationRenumber` (version to 0.2.0)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
+0.2.0
+------
+
+Added
++++++
+* ``MutationRenumber`` class to enable re-numbering of mutations.
+
 0.1.6
 ------
 

--- a/alignparse/__init__.py
+++ b/alignparse/__init__.py
@@ -7,5 +7,5 @@ alignparse
 
 __author__ = '`the Bloom lab <https://research.fhcrc.org/bloom/en.html>`_'
 __email__ = 'jbloom@fredhutch.org'
-__version__ = '0.1.6'
+__version__ = '0.2.0'
 __url__ = 'https://github.com/jbloomlab/alignparse'


### PR DESCRIPTION
@Bernadetadad, related to the issues with the PacBio renumbering, I have added a class, `utils.MutationRenumber`, that re-numbers mutations along with error checking. It's in this pull request. Can you review and merge? I will then adjust my branch of the project repo to use this code.

By the way, here is the rendered documentation for the new class in addition to the code updates in this pull request:
![Screen Shot 2020-11-24 at 1 39 16 PM](https://user-images.githubusercontent.com/1906801/100154605-b4315b80-2e5a-11eb-8ca0-301e68ceb0f2.png)
