### PR TITLE
add `sort_mutations` (version to 0.2.1)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
+0.2.1
+-----
+* ``sort_mutations`` function to sort mutations by site, and optionally concatenate them.
+
 0.2.0
 ------
 

--- a/alignparse/__init__.py
+++ b/alignparse/__init__.py
@@ -7,5 +7,5 @@ alignparse
 
 __author__ = '`the Bloom lab <https://research.fhcrc.org/bloom/en.html>`_'
 __email__ = 'jbloom@fredhutch.org'
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 __url__ = 'https://github.com/jbloomlab/alignparse'

--- a/alignparse/utils.py
+++ b/alignparse/utils.py
@@ -39,6 +39,9 @@ def qvals_to_accuracy(qvals, encoding='numbers'):
     the Q-value :math:`Q` by :math:`Q = -10 \log_{10} p`. The accuracy
     is one minus the average error rate.
 
+    Example
+    -------
+
     >>> qvals = numpy.array([13, 77, 93])
     >>> round(qvals_to_accuracy(qvals), 3)
     0.983
@@ -72,6 +75,48 @@ def qvals_to_accuracy(qvals, encoding='numbers'):
         raise ValueError(f"invalid `encoding`: {encoding}")
 
     return (1 - 10**(qvals / -10)).sum() / len(qvals)
+
+
+def sort_mutations(mut_strs):
+    """Sort mutation string by site, and combine multiple mutation strings.
+
+    Parameters
+    ----------
+    mut_strs : str or list
+        A single mutation string or a list of such strings.
+
+    Returns
+    -------
+    str
+        A single mutation string with all mutations sorted by site.
+
+    Example
+    -------
+    Sort a single mutation string:
+
+    >>> sort_mutations('ins7GC A5C del2to3')
+    'del2to3 A5C ins7GC'
+
+    Sort a list of two mutation strings:
+
+    >>> sort_mutations(['ins7GC', 'A5C del2to3'])
+    'del2to3 A5C ins7GC'
+
+    """
+    if isinstance(mut_strs, str):
+        mut_strs = [mut_strs]
+    decorated_list = []
+    for mut_str in mut_strs:
+        for mut in mut_str.split():
+            m = re.fullmatch(r'ins(\d+)[A-Z]+|[A-Z](\d+)[A-Z]|del(\d+)to\d+',
+                             mut)
+            if not m:
+                raise ValueError(f"failed to match {mut} in:\n{mut_str}")
+            site = [site for site in m.groups() if site is not None]
+            assert len(site) == 1
+            site = int(site[0])
+            decorated_list.append((site, mut))
+    return ' '.join(mut for _, mut in sorted(decorated_list))
 
 
 class MutationRenumber:


### PR DESCRIPTION
@Bernadetadad, another pull request here for you to take a look at.

The rendered documentation is here:
![Screen Shot 2020-11-25 at 9 57 01 AM](https://user-images.githubusercontent.com/1906801/100265230-cf58a580-2f04-11eb-96a5-bd0a26e85ff9.png)

This is based on suggestion I'm about to make in viral sequencing channel that we also need to add a column to the final data frame that simply aggregates in sorted order all of the mutations in that gene. I will post about that separately in the project channel. 