### PR TITLE
Handle tags of type B

### DIFF
--- a/alignparse/minimap2.py
+++ b/alignparse/minimap2.py
@@ -296,19 +296,32 @@ class Mapper:
                             for tag in self.retain_tags:
                                 m = matchers[tag].search(query.comment)
                                 if not m:
-                                    raise ValueError(f"no tag {tag}:\n{query}")
+                                    if tag == 'MM':
+                                        continue
+                                    else:
+                                        raise ValueError(f"no tag {tag}:\n{query}")
                                 valtype = m.group("valtype")
-                                if valtype == "i":
-                                    val = int(m.group("val"))
-                                elif valtype == "f":
-                                    val = float(m.group("val"))
-                                elif valtype in {"A", "Z"}:
-                                    val = m.group("val")
+                                if valtype == 'B':
+                                    val_temp = m.group("val")
+                                    val_ints = val_temp[2:]
+                                    # skip if the B-type tag if only a letter and no ints, then it is an empty tag
+                                    if val_ints == '':
+                                        continue
+                                    val_list = val_ints.split(',')
+                                    val_list_int = list(map(int, val_list))
+                                    a.set_tag(tag, val_list_int)
                                 else:
-                                    raise ValueError(
-                                        f"bad tag type {valtype} " f"for tag {tag}"
-                                    )
-                                a.set_tag(tag, val, valtype)
+                                    if valtype == "i":
+                                        val = int(m.group("val"))
+                                    elif valtype == "f":
+                                        val = float(m.group("val"))
+                                    elif valtype in {"A", "Z"}:
+                                        val = m.group("val")
+                                    else:
+                                        raise ValueError(
+                                            f"bad tag type {valtype} " f"for tag {tag}"
+                                        )
+                                    a.set_tag(tag, val, valtype)
                         except StopIteration:
                             raise ValueError(
                                 f"No entry in {queryfile} for "


### PR DESCRIPTION
About changing the raise ValueError after line 298:
It might be nice to be able to allow an 'empty' or not present tag in some cases, I needed this for the 'MM' tag, but it might be possible to create an argument that takes in a list of tags that are allowed to be empty or not present in some of the reads

About adding the B-type:
created a separate part for valtype B, it does not supply the valtype to the set_tag function, because set_tag can automatically infer the type when it is supplied with a list of int, set_tag also automatically infers the 'number type' of the integers supplied in a B-type tag.